### PR TITLE
fix: event `target` and `currentTarget`

### DIFF
--- a/src/dummy/xhr.ts
+++ b/src/dummy/xhr.ts
@@ -101,8 +101,8 @@ export default class dummyXMLHttpRequest {
   private event(type: string) {
     return {
       type,
-      target: null,
-      currentTarget: null,
+      target: this,
+      currentTarget: this,
       eventPhase: 0,
       bubbles: false,
       cancelable: false,

--- a/src/interceptor/xml-http-request.ts
+++ b/src/interceptor/xml-http-request.ts
@@ -329,8 +329,8 @@ export default class XMLHttpRequestInterceptor extends Base {
   private event(type: string) {
     return {
       type,
-      target: null,
-      currentTarget: null,
+      target: this.xhr,
+      currentTarget: this.xhr,
       eventPhase: 0,
       bubbles: false,
       cancelable: false,


### PR DESCRIPTION
Thank you for your excellent work! It helped me save a lot of time.

I just found a bug and fixed here. I couldn't find relevant spec, but in my experimental results, it seems that both of these attributes point to the XHR instance.