### PR TITLE
Support URL objects as the first argument of fetches

### DIFF
--- a/src/dummy/fetch.ts
+++ b/src/dummy/fetch.ts
@@ -4,12 +4,18 @@ import { isArrayBuffer, str2arrayBuffer, tryToParseJson } from '../common/utils'
 import { HTTPStatusCodes } from '../config';
 import { AnyObject, FetchRequest } from '../types';
 
-export default function dummyFetch(input: string | FetchRequest, init: AnyObject) {
+export default function dummyFetch(
+  input: string | FetchRequest | URL,
+  init: AnyObject
+) {
   let url: string | FetchRequest;
   let params: FetchRequest | AnyObject;
-  // https://developer.mozilla.org/en-US/docs/Web/API/Request
-  // Note: the first argument of fetch maybe a Request object.
-  if (typeof input === 'object') {
+  // https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch
+  // Note: the first argument of fetch maybe a Request or URL object.
+  if (input instanceof URL) {
+    url = input.toString();
+    params = init || {};
+  } else if (typeof input === 'object') {
     url = input.url;
     params = input as FetchRequest;
   } else {
@@ -18,11 +24,11 @@ export default function dummyFetch(input: string | FetchRequest, init: AnyObject
   }
 
   return simpleRequest({
-    url, method:
-    params.method as string,
+    url,
+    method: params.method as string,
     headers: params.headers as Record<string, string>,
-    body: params.body
-  }).then((res: {body: string, response: IncomingMessage}) => {
+    body: params.body,
+  }).then((res: { body: string; response: IncomingMessage }) => {
     return getResponse(url as string, res.body, res.response);
   });
 }

--- a/src/interceptor/fetch.ts
+++ b/src/interceptor/fetch.ts
@@ -52,7 +52,7 @@ export default class FetchInterceptor extends Base{
         const mockItem:MockItem | null = me.matchMockRequest(requestUrl, method);
 
         if (!mockItem) {
-          me.fetch(requestUrl, params).then(resolve).catch(reject);
+          me.fetch(input, init).then(resolve).catch(reject);
           return;
         }
 

--- a/src/interceptor/fetch.ts
+++ b/src/interceptor/fetch.ts
@@ -33,23 +33,34 @@ export default class FetchInterceptor extends Base{
   private intercept() {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const me = this;
-    this.global.fetch = function(input: string | FetchRequest, init: AnyObject) {
+    this.global.fetch = function (
+      input: string | FetchRequest | URL,
+      init: AnyObject
+    ) {
       let url: string;
       let params: FetchRequest | AnyObject;
-      // https://developer.mozilla.org/en-US/docs/Web/API/Request
-      // Note: the first argument of fetch maybe a Request object.
-      if (typeof input === 'object') {
+      // https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch
+      // Note: the first argument of fetch maybe a Request or URL object.
+      if (input instanceof URL) {
+        url = input.toString();
+        params = init || {};
+      } else if (typeof input === 'object') {
         url = input.url;
         params = input;
       } else {
         url = input;
         params = init || {};
       }
-      const method = (params && params.method ? params.method : 'GET') as unknown as HttpVerb;
+      const method = (params && params.method
+        ? params.method
+        : 'GET') as unknown as HttpVerb;
       const requestUrl = me.getFullRequestUrl(url, method);
 
       return new Promise((resolve, reject) => {
-        const mockItem:MockItem | null = me.matchMockRequest(requestUrl, method);
+        const mockItem: MockItem | null = me.matchMockRequest(
+          requestUrl,
+          method
+        );
 
         if (!mockItem) {
           me.fetch(input, init).then(resolve).catch(reject);
@@ -58,7 +69,11 @@ export default class FetchInterceptor extends Base{
 
         me.setTimeoutForSingal(params as FetchRequest, reject);
 
-        const requestInfo = me.getRequestInfo({ ...params, url: requestUrl, method: method as HttpVerb });
+        const requestInfo = me.getRequestInfo({
+          ...params,
+          url: requestUrl,
+          method: method as HttpVerb,
+        });
         requestInfo.doOriginalCall = async (): Promise<OriginalResponse> => {
           const res = await me.getOriginalResponse(requestUrl, params);
           requestInfo.doOriginalCall = undefined;
@@ -69,13 +84,20 @@ export default class FetchInterceptor extends Base{
         if (remoteInfo) {
           params.method = remoteInfo.method || method;
           me.setRequestHeadersForRemoteRequest(mockItem, params as AnyObject);
-          me.fetch(remoteInfo.url, params).then((fetchResponse: FetchResponse) => {
-            me.sendRemoteResult(fetchResponse, mockItem, requestInfo, resolve);
-          }).catch(reject);
+          me.fetch(remoteInfo.url, params)
+            .then((fetchResponse: FetchResponse) => {
+              me.sendRemoteResult(
+                fetchResponse,
+                mockItem,
+                requestInfo,
+                resolve
+              );
+            })
+            .catch(reject);
           return;
         }
 
-        me.doMockRequest(mockItem, requestInfo, resolve).then(isBypassed => {
+        me.doMockRequest(mockItem, requestInfo, resolve).then((isBypassed) => {
           if (isBypassed) {
             me.fetch(requestUrl, params).then(resolve).catch(reject);
           }

--- a/test/browser-fetch.test.js
+++ b/test/browser-fetch.test.js
@@ -245,4 +245,16 @@ describe('mock fetch requests for browser envrioment', () => {
     console.log('res:', res);
     expect(res).toBe('an error should be caught');
   });
+
+  it('should support URL objects being passed into fetch', async () => {
+    mocker.mock({
+      url: 'http://example.com/some/api',
+      method: 'post',
+      body: () => 'some mock response',
+    });
+    const res = await fetch(new URL('http://example.com/some/other/api'), {
+      method: 'post',
+    });
+    expect(res.status).toBe(404);
+  });
 });

--- a/test/browser-fetch.test.js
+++ b/test/browser-fetch.test.js
@@ -247,14 +247,10 @@ describe('mock fetch requests for browser envrioment', () => {
   });
 
   it('should support URL objects being passed into fetch', async () => {
-    mocker.mock({
-      url: 'http://example.com/some/api',
-      method: 'post',
-      body: () => 'some mock response',
-    });
+    mocker.get('http://example.com/some/api', 'get content');
     const res = await fetch(new URL('http://example.com/some/other/api'), {
       method: 'post',
-    });
-    expect(res.status).toBe(404);
+    }).then((res) => res.text());
+    expect(res).toBe('get content');
   });
 });


### PR DESCRIPTION
As described in the [fetch docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch), the first argument of a fetch can be a URL object. This is currently not supported in this library, and will lead to doing a fetch to `/undefined` if a URL is passed as the first argument.

As an aside, I have also changed the logic that calls the original fetch (if a request is not mocked) to longer call it with the modified `url` and `params`, but instead with the original `input` and `init` arguments. This improves the package's ability to not modify an outgoing request beyond what is needed, if that request is not currently mocked.